### PR TITLE
Resolve ENG-3038 point-regarding numeric machine_type error/Added support for display name in kpi endpoint

### DIFF
--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -262,6 +262,24 @@ class Client(ClientV0):
         base_url = get_url(
             self.config["protocol"], self.tenant, self.config["site.domain"]
         )
+
+        # Get machine_types dataframe to check display name
+        machine_types_df = self.get_machine_types()
+        machine_types = []
+        # This loop is getting system name of machine_type if provided only display name in request.
+        for machine_type in kwargs["asset_selection"]["machine_type"]:
+            source_type = machine_types_df.loc[
+                machine_types_df["source_type_clean"] == machine_type, "source_type"
+            ]
+            if not source_type.empty:
+                source_type = list(set(source_type.to_list()))
+                machine_types.extend(source_type)
+            else:
+                machine_types.append(machine_type)
+
+        # updating kwargs with machine_type's system name only
+        kwargs["asset_selection"]["machine_type"] = machine_types
+
         return kpis(self.session, base_url).get_kpis_for_asset(**kwargs)
 
     def get_kpi_data_viz(

--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -1069,12 +1069,13 @@ class ClientV0(object):
                     return table
 
         # Handle EF type machine names
-        if len(machine) <= 6 and machine[:3].isnumeric():
-            machine = f"'{machine}'"
+        # Commenting these out because we already are getting machine_names as string even if they are in numerics.
+        # if len(machine) <= 6 and machine[:3].isnumeric():
+        # machine = f"'{machine}'"
 
         # Handle EF type machine names
-        if len(machine) == 5 and machine[:3].isnumeric():
-            machine = f"'{machine}'"
+        # if len(machine) == 5 and machine[:3].isnumeric():
+        # machine = f"'{machine}'"
 
         schema = self.get_machine_schema(machine)
 

--- a/smsdk/ma_session.py
+++ b/smsdk/ma_session.py
@@ -95,7 +95,7 @@ class MaSession:
                 _offset += this_loop_limit
 
             except Exception as e:
-                print(f'Error getting data, but continuing. {e}')
+                print(f"Error getting data, but continuing. {e}")
                 continue
 
     def _get_schema(self, endpoint, method="get", **url_params):
@@ -200,7 +200,7 @@ class MaSession:
             except ValueError as e:
                 raise e
             except Exception as e:
-                print(f'Error getting data, retrying with smaller page size. {e}')
+                print(f"Error getting data, retrying with smaller page size. {e}")
                 # Try throttling down the page size
                 max_page_size = int(max_page_size / 2)
                 continue
@@ -232,15 +232,9 @@ class MaSession:
                     if state == "FAILURE" or state == "REVOKED":
                         raise ValueError("Error - {}".format(response.text))
                 except:
-                    import traceback
-
-                    print(traceback.print_exc())
-                    return []
+                    return response.text
         except:
-            import traceback
-
-            print(traceback.print_exc())
-            return []
+            return response.text
 
     def get_json_headers(self):
         """

--- a/tests/kpi/test_kpi.py
+++ b/tests/kpi/test_kpi.py
@@ -87,12 +87,24 @@ def test_get_kpi_data_viz(mocked):
 
 def test_kpi_for_asset_display_name(get_client):
     kpis = ["performance", "oee", "quality", "availability"]
-    query = {"asset_selection": {"machine_type": ["PickAndPlace"]}}
+    # Query against machine type system name and machine source system name
+    query = {
+        "asset_selection": {
+            "machine_type": ["PickAndPlace"],
+            "machine_source": ["JB_NG_PickAndPlace_1_Stage6"],
+        }
+    }
     df1 = get_client.get_kpis_for_asset(**query)
     assert len(df1) > 0
     assert df1[0]["name"] in kpis
 
-    query = {"asset_selection": {"machine_type": ["Pick & Place"]}}
+    # Query against machine type display name and machine source display name
+    query = {
+        "asset_selection": {
+            "machine_type": ["Pick & Place"],
+            "machine_source": ["Nagoya - Pick and Place 6"],
+        }
+    }
     df2 = get_client.get_kpis_for_asset(**query)
     assert len(df2) > 0
     assert df2[0]["name"] in kpis

--- a/tests/kpi/test_kpi.py
+++ b/tests/kpi/test_kpi.py
@@ -83,3 +83,18 @@ def test_get_kpi_data_viz(mocked):
     data = dt.get_kpi_data_viz()
     assert len(data) == 3
     assert data[0]["d_vals"]["quality"]["avg"] == 95.18072289156626
+
+
+def test_kpi_for_asset_display_name(get_client):
+    kpis = ["performance", "oee", "quality", "availability"]
+    query = {"asset_selection": {"machine_type": ["PickAndPlace"]}}
+    df1 = get_client.get_kpis_for_asset(**query)
+    assert len(df1) > 0
+    assert df1[0]["name"] in kpis
+
+    query = {"asset_selection": {"machine_type": ["Pick & Place"]}}
+    df2 = get_client.get_kpis_for_asset(**query)
+    assert len(df2) > 0
+    assert df2[0]["name"] in kpis
+
+    assert df1 == df2


### PR DESCRIPTION
When trying to call get_machine_type with a numeric value we should not want to encapsulate it with additional quotes as it’s already in String even if it is in numeric format.

So I have made some changes to resolve in this PR.