### PR TITLE
Integrate static type checking on SDK with CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ workflows:
     jobs:
       - black-python-code-formatter:
           context: org-sightmachine
+      - mypy-type-checks:
+          context: org-sightmachine
       - run-unit-tests:
           context: org-sightmachine
 
@@ -94,3 +96,42 @@ jobs:
               echo "Unformatted code detected. Please run black --fast . locally and commit to format your code." >&2
               exit 1
             fi
+
+  ## ------------------ Mypy for Static Type Checking python code ------------------
+  mypy-type-checks:
+    parameters:
+      with_merge: # Part of the PR-merge workflow
+        type: boolean
+        default: false
+    docker:
+      # https://circleci.com/developer/images/image/cimg/python
+      - image: cimg/python:3.11.0
+    steps:
+      - when:
+          condition: << parameters.with_merge >>
+          steps:
+            - disable_build_if_not_pr
+      - checkout
+      # Run Pyre type checking
+      - run:
+          name: Run Static type checking
+          command: |
+            set -x
+            # Install Python packages for type checking
+            pip wheel --wheel-dir=./wheel-dir -r requirements-type-checks.txt
+            pip install --find-links=./wheel-dir -r requirements-type-checks.txt
+            # Using 'git diff ...' to fetch newly added Python files from the repo
+            # Conducting static type checking on the files obtained
+            # Re-running static type checking on the files listed in 'mypy.ini'
+            mypy $(git diff --name-only --diff-filter=A origin/master HEAD | grep '\.py$') && mypy
+            if [ $? -ne 0 ]; then
+                echo "MyPy finds static type error(s) in the Python codebase. Please fix all type-related errors before committing the code." >&2
+                exit 1
+            fi
+      # Store MyPy type checking results
+      - store_test_results:
+          path: mypy-results
+      # Store MyPy type checking artifacts (e.g., HTML reports)
+      - store_artifacts:
+          name: MyPy Artifacts
+          path: mypy-results/mypy-html

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,0 +1,13 @@
+{
+  "site_package_search_strategy": "all",
+  "source_directories": [
+      {
+          "import_root": ".",
+          "source": "smsdk"
+      }
+  ],
+  "search_path": [
+    "smsdk"
+  ],
+  "strict": true
+}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,53 @@
+[mypy]
+html_report = mypy-results/mypy-html
+junit_xml = mypy-results/junit.xml
+
+# # The following config is equivalent to 'strict = True'
+
+# # Start off with these
+# warn_unused_configs = True
+# warn_redundant_casts = True
+# warn_unused_ignores = True
+
+# # Getting these passing should be easy
+# strict_equality = True
+# strict_concatenate = True
+
+# # Strongly recommend enabling this one as soon as you can
+# check_untyped_defs = True
+
+# # These shouldn't be too much additional work, but may be tricky to
+# # get passing if you use a lot of untyped libraries
+# disallow_subclassing_any = True
+# disallow_untyped_decorators = True
+# disallow_any_generics = True
+
+# # These next few are various gradations of forcing use of type annotations
+# disallow_untyped_calls = True
+# disallow_incomplete_defs = True
+# disallow_untyped_defs = True
+
+# # This one isn't too hard to get passing, but return on investment is lower
+# no_implicit_reexport = True
+
+# # This one can be tricky to get passing if you use a lot of untyped libraries
+# warn_return_any = True
+
+strict = True
+
+warn_unused_configs = False
+warn_unused_ignores = False
+; warn_redundant_casts = False
+disallow_untyped_decorators = False
+
+
+show_error_codes = True
+warn_redundant_casts = False
+no_site_packages = True
+
+ignore_missing_imports = True
+follow_imports = silent
+
+
+# Files free from Static type check errors
+files = smsdk/utils.py, smsdk/tool_register.py, smsdk/ma_session.py

--- a/requirements-type-checks.txt
+++ b/requirements-type-checks.txt
@@ -1,0 +1,5 @@
+--index-url https://circleci-read-user:X5KJ7hOBIM@sightmachine.jfrog.io/sightmachine/api/pypi/python-dependencies/simple
+
+pyre-check==0.9.18
+mypy==1.6.0
+lxml==4.9.3

--- a/smsdk/ma_session.py
+++ b/smsdk/ma_session.py
@@ -1,6 +1,6 @@
 from json.decoder import JSONDecodeError
 from time import sleep
-from typing import List
+import typing as t_
 import json
 import requests
 
@@ -8,16 +8,21 @@ import numpy as np
 
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import Session
-
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources as pkg_resources
-
 from smsdk import config
 
-RESOURCE_CONFIG = json.loads(pkg_resources.read_text(config, "message_config.json"))
+try:
+    import importlib.resources
+
+    RESOURCE_CONFIG = json.loads(
+        importlib.resources.read_text(config, "message_config.json")
+    )
+except ImportError:
+    # Try backported to PY<37 `importlib_resources`.
+    import importlib_resources
+
+    RESOURCE_CONFIG = json.loads(
+        importlib_resources.read_text(config, "message_config.json")
+    )
 
 SM_AUTH_HEADER_SECRET_ID = RESOURCE_CONFIG["auth_header-api-secret"]
 SM_AUTH_HEADER_SECRET_ID_OLD = RESOURCE_CONFIG["auth_header-api-secret_old"]
@@ -31,13 +36,18 @@ log = logging.getLogger(__name__)
 
 
 class MaSession:
-    def __init__(self):
+    def __init__(self) -> None:
         self.requests = requests
         self.session = Session()
 
     def _get_records(
-        self, endpoint, method="get", _limit=np.Inf, _offset=0, **url_params
-    ):
+        self,
+        endpoint: str,
+        method: str = "get",
+        _limit: float = np.Inf,
+        _offset: float = 0.0,
+        **url_params: t_.Any,
+    ) -> t_.List[t_.Dict[str, t_.Any]]:
         """
         Function to get api call and fetch data from MA APIs
         :param endpoint: complete url endpoint
@@ -53,7 +63,7 @@ class MaSession:
             url_params.pop("machine_type")
         max_page_size = 2000
 
-        records: List = []
+        records: t_.List[t_.Dict[str, t_.Any]] = []
         while True:
             try:
                 remaining_limit = _limit - len(records)
@@ -98,7 +108,9 @@ class MaSession:
                 print(f"Error getting data, but continuing. {e}")
                 continue
 
-    def _get_schema(self, endpoint, method="get", **url_params):
+    def _get_schema(
+        self, endpoint: str, method: str = "get", **url_params: t_.Any
+    ) -> t_.Any:
         """
         This function can be used to fetch HLO schemas like AIDP
         Function to get api call and fetch data from MA APIs
@@ -130,14 +142,14 @@ class MaSession:
 
     def _get_records_v1(
         self,
-        endpoint,
-        method="post",
-        limit=np.Inf,
-        offset=0,
-        db_mode="sql",
-        results_under="results",
-        **url_params,
-    ):
+        endpoint: str,
+        method: str = "post",
+        limit: float = np.Inf,
+        offset: float = 0,
+        db_mode: str = "sql",
+        results_under: str = "results",
+        **url_params: t_.Any,
+    ) -> t_.List[t_.Dict[str, t_.Any]]:
         """
         Function to get api call and fetch data from MA APIs
         :param endpoint: complete url endpoint
@@ -151,7 +163,7 @@ class MaSession:
         """
         max_page_size = 50000
 
-        records: List = []
+        records: t_.List[t_.Dict[str, t_.Any]] = []
         while True:
             try:
                 if limit:
@@ -206,8 +218,12 @@ class MaSession:
                 continue
 
     def _complete_async_task(
-        self, endpoint, method="post", db_mode="sql", **url_params
-    ):
+        self,
+        endpoint: str,
+        method: str = "post",
+        db_mode: str = "sql",
+        **url_params: t_.Any,
+    ) -> t_.Any:
         if url_params.get("db_mode") == None:
             url_params["db_mode"] = db_mode
         try:
@@ -234,15 +250,15 @@ class MaSession:
                 except:
                     import traceback
 
-                    print(traceback.print_exc())
+                    traceback.print_exc()
                     return []
         except:
             import traceback
 
-            print(traceback.print_exc())
+            traceback.print_exc()
             return []
 
-    def get_json_headers(self):
+    def get_json_headers(self) -> CaseInsensitiveDict:
         """
         Headers for json requests
         """
@@ -254,7 +270,7 @@ class MaSession:
             }
         )
 
-    def get_starttime_endtime_keys(self, **kwargs):
+    def get_starttime_endtime_keys(self, **kwargs: t_.Any) -> t_.Tuple[str, str]:
         """
         This function takes kwargs as input and tried to identify starttime and endtime key provided by user and returns
         :param kwargs:

--- a/smsdk/tool_register.py
+++ b/smsdk/tool_register.py
@@ -4,6 +4,7 @@ import enum
 from typing import List, Dict, NamedTuple, Tuple, Union
 
 from smsdk.register import Registry
+import typing as t_
 
 
 @enum.unique
@@ -47,9 +48,13 @@ class SmsdkEntities(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def __init__(self, session, base_url) -> None:
-        self.session = session
-        self.base_url = base_url
+    # The subclasses of the SmsdkEntities class will be responsible
+    # for defining their own __init__() methods, which will initialize
+    # the session and base_url attributes.
+    def __init__(self, session: t_.Any, base_url: str) -> None:
+        # self.session = session
+        # self.base_url = base_url
+        pass
 
 
 smsdkentities = Registry(SmsdkEntities)

--- a/smsdk/utils.py
+++ b/smsdk/utils.py
@@ -1,20 +1,26 @@
-def module_utility():
-    """
-    Function to register class functions as tool functions
-    :return:
-    """
-    registry = {}
-
-    def registrar(func):
-        registry[func.__name__] = func
-        return func  # normally a decorator returns a wrapped function,
-        # but here we return func unmodified, after registering it
-
-    registrar.all = registry
-    return registrar
+import typing as t_
+import functools
+from typing import Any
 
 
-def get_url(protocol, tenant, site_domain):
+class ModuleUtility:
+    def __init__(self) -> None:
+        self.registry: t_.Dict[str, t_.Callable[..., t_.Any]] = {}
+
+    def __call__(self, func: t_.Callable[..., t_.Any]) -> t_.Callable[..., t_.Any]:
+        self.registry[func.__name__] = func
+        return func
+
+    @property
+    def all(self) -> t_.Dict[str, t_.Callable[..., t_.Any]]:
+        return self.registry
+
+
+# To avoid modifying all the files with the class name, this alias is created.
+module_utility = ModuleUtility
+
+
+def get_url(protocol: str, tenant: str, site_domain: str) -> str:
     """
     Get the URL of the web address.
 
@@ -26,4 +32,4 @@ def get_url(protocol, tenant, site_domain):
     :type site_domain: :class:`string`
     """
 
-    return "{}://{}.{}".format(protocol, tenant, site_domain)
+    return f"{protocol}://{tenant}.{site_domain}"


### PR DESCRIPTION
Integrated static type checking into the SDK using CI/CD integration. Specifically:

1) I incorporated MyPy into Circle CI for performing static type checks before merging PRs into the master branch.
2) The aim of this integration is to perform static type checking on all Python files, gradually, within the "smsdk" directory.
3) As a started, I am made just three files free of any static type errors: "smsdk/utils.py," "smsdk/tool_register.py," and "smsdk/ma_session.py."
4) The Circle CI integration process also performs static type checking on any new Python file added to the git committ.
5) It is expected that the commit owner rectifies any static type errors in the newly created file before adding it to the repository. Additionally, this file must be included in the list of files in the "mypy.ini" configuration.