### PR TITLE
Fix for the issue 'Unable to pull all columns with the SDK'

### DIFF
--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -317,24 +317,22 @@ class ClientV0(object):
                 only_names = schema["name"].tolist()[:50]
                 kwargs["_only"] = only_names
             else:
-                if (
-                    ("End Time" not in kwargs["_only"])
-                    and ("endtime" not in kwargs["_only"])
-                    and ("Cycle End Time" not in kwargs["_only"])
+                if all(
+                    i not in {"End Time", "endtime", "Cycle End Time"}
+                    for i in kwargs["_only"]
                 ):
                     print("Adding End Time to _only")
                     kwargs["_only"].insert(0, "End Time")
 
-                if (
-                    ("Start Time" not in kwargs["_only"])
-                    and ("starttime" not in kwargs["_only"])
-                    and ("Cycle Start Time" not in kwargs["_only"])
+                if all(
+                    i not in {"Start Time", "starttime", "Cycle Start Time"}
+                    for i in kwargs["_only"]
                 ):
                     print("Adding Start Time to _only")
                     kwargs["_only"].insert(0, "Start Time")
 
-                if ("Machine" not in kwargs["_only"]) and (
-                    "machine__source" not in kwargs["_only"]
+                if all(
+                    i not in {"Machine", "machine__source"} for i in kwargs["_only"]
                 ):
                     print("Adding Machine to _only")
                     kwargs["_only"].insert(0, "Machine")

--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -317,11 +317,21 @@ class ClientV0(object):
                 only_names = schema["name"].tolist()[:50]
                 kwargs["_only"] = only_names
             else:
-                if ("End Time" not in kwargs["_only"]) and (
-                    "endtime" not in kwargs["_only"]
+                if (
+                    ("End Time" not in kwargs["_only"])
+                    and ("endtime" not in kwargs["_only"])
+                    and ("Cycle End Time" not in kwargs["_only"])
                 ):
                     print("Adding End Time to _only")
                     kwargs["_only"].insert(0, "End Time")
+
+                if (
+                    ("Start Time" not in kwargs["_only"])
+                    and ("starttime" not in kwargs["_only"])
+                    and ("Cycle Start Time" not in kwargs["_only"])
+                ):
+                    print("Adding Start Time to _only")
+                    kwargs["_only"].insert(0, "Start Time")
 
                 if ("Machine" not in kwargs["_only"]) and (
                     "machine__source" not in kwargs["_only"]

--- a/tests/cycle/test_cycle.py
+++ b/tests/cycle/test_cycle.py
@@ -54,8 +54,219 @@ def test_get_cycles(get_client):
         "End Time__lte": END_DATETIME,
         "_order_by": "-End Time",
         "_limit": NUM_ROWS,
+        "_only": columns,
     }
 
     df = get_client.get_cycles(**query)
 
     assert df.shape == (NUM_ROWS, len(columns))
+
+
+def test_get_cycles_machine_tag(get_client):
+    machines = get_client.get_machine_names(source_type=MACHINE_TYPE)
+    machine = machines[MACHINE_INDEX]
+    columns = get_client.get_machine_schema(machine)["display"].to_list()
+
+    select_columns = [
+        # "Machine",
+        "Cycle Start Time",
+        "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape != (NUM_ROWS, len(select_columns))
+
+    select_columns = [
+        "machine__source",
+        "Cycle Start Time",
+        "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape == (NUM_ROWS, len(select_columns))
+
+
+def test_get_cycles_starttime_tag(get_client):
+    machines = get_client.get_machine_names(source_type=MACHINE_TYPE)
+    machine = machines[MACHINE_INDEX]
+    columns = get_client.get_machine_schema(machine)["display"].to_list()
+
+    select_columns = [
+        "Machine",
+        # "Cycle Start Time",
+        "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape != (NUM_ROWS, len(select_columns))
+
+    select_columns = [
+        "Machine",
+        "starttime",
+        "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape == (NUM_ROWS, len(select_columns))
+
+    select_columns = [
+        "Machine",
+        "Start Time",
+        "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape == (NUM_ROWS, len(select_columns))
+
+
+def test_get_cycles_endtime_tag(get_client):
+    machines = get_client.get_machine_names(source_type=MACHINE_TYPE)
+    machine = machines[MACHINE_INDEX]
+    columns = get_client.get_machine_schema(machine)["display"].to_list()
+
+    select_columns = [
+        "Machine",
+        "Cycle Start Time",
+        # "Cycle End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape != (NUM_ROWS, len(select_columns))
+
+    select_columns = [
+        "Machine",
+        "Cycle Start Time",
+        "endtime",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape == (NUM_ROWS, len(select_columns))
+
+    select_columns = [
+        "Machine",
+        "Cycle Start Time",
+        "End Time",
+        "Production Day",
+        "Cycle Time (Net)",
+        "Cycle Time (Gross)",
+    ]
+
+    col = select_columns.copy()
+
+    query = {
+        "Machine": machine,
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": col,
+    }
+
+    df = get_client.get_cycles(**query)
+
+    assert df.shape == (NUM_ROWS, len(select_columns))


### PR DESCRIPTION
Based on the current smsdk source code, I inferred that 'machine__source' and 'endtime' are mandatory tags for the successful execution of the 'select' query. If they are missing in the '_only' tags list of the query, they are added programmatically. However, during the check of the 'endtime' tag in the list, we are not considering the display name 'Cycle End Time.' We are only looking for 'endtime' and 'End Time.' This leads to the duplicate 'endtime' tag in the select query, causing the issue.

I have fixed this by adding the display name of the tag 'Cycle End Time' for the conditional check to determine its existence in the '_only' list before.

Additionally, I found that not only the two tags, 'machine__source' and 'endtime,' but also the tag 'starttime' are required for the successful execution of the 'select' query. I have started adding 'starttime' to the query if it is missing in the '_only' list.

With the above two changes, I am able to run the client notebook without any issues.