### PR TITLE
Added clean name to accept in get_kpi_for_asset sdk function

### DIFF
--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -257,12 +257,7 @@ class Client(ClientV0):
         )
         return kpis(self.session, base_url).get_kpis(**kwargs)
 
-    def get_kpis_for_asset(self, **kwargs):
-        kpis = smsdkentities.get("kpi")
-        base_url = get_url(
-            self.config["protocol"], self.tenant, self.config["site.domain"]
-        )
-
+    def get_machine_type_from_clean_name(self, kwargs):
         # Get machine_types dataframe to check display name
         machine_types_df = self.get_machine_types()
 
@@ -274,31 +269,45 @@ class Client(ClientV0):
             .apply(set)
             .to_dict()
         )
-
         machine_types = []
         for machine_type in kwargs["asset_selection"]["machine_type"]:
             machine_types.extend(alias_tbl.get(machine_type, (machine_type,)))
 
-        # updating kwargs with machine_type's system name
-        kwargs["asset_selection"]["machine_type"] = machine_types
+        return machine_types
+
+    def get_machine_source_from_clean_name(self, kwargs):
+        # Get machines dataframe to check display/clean name
+        machine_sources_df = self.get_machines()
+        alias_tbl = (
+            machine_sources_df.loc[:, ["source", "source_clean"]]
+            .set_index("source_clean")
+            .groupby("source_clean")["source"]
+            .apply(set)
+            .to_dict()
+        )
+
+        machine_sources = []
+        for machine_source in kwargs["asset_selection"]["machine_source"]:
+            machine_sources.extend(alias_tbl.get(machine_source, (machine_source,)))
+
+        return machine_sources
+
+    def get_kpis_for_asset(self, **kwargs):
+        kpis = smsdkentities.get("kpi")
+        base_url = get_url(
+            self.config["protocol"], self.tenant, self.config["site.domain"]
+        )
+        if "machine_type" in kwargs["asset_selection"]:
+            # updating kwargs with machine_type's system name in case of user provides display name.
+            kwargs["asset_selection"][
+                "machine_type"
+            ] = self.get_machine_type_from_clean_name(kwargs)
 
         if "machine_source" in kwargs["asset_selection"]:
-            # Get machines dataframe to check display/clean name
-            machine_sources_df = self.get_machines()
-            alias_tbl = (
-                machine_sources_df.loc[:, ["source", "source_clean"]]
-                .set_index("source_clean")
-                .groupby("source_clean")["source"]
-                .apply(set)
-                .to_dict()
-            )
-
-            machine_sources = []
-            for machine_source in kwargs["asset_selection"]["machine_source"]:
-                machine_sources.extend(alias_tbl.get(machine_source, (machine_source,)))
-
-            # updating kwargs with machine_source's system name
-            kwargs["asset_selection"]["machine_source"] = machine_sources
+            # updating kwargs with machine_source's system name in case of user provides display name.
+            kwargs["asset_selection"][
+                "machine_source"
+            ] = self.get_machine_source_from_clean_name(kwargs)
 
         return kpis(self.session, base_url).get_kpis_for_asset(**kwargs)
 
@@ -337,6 +346,19 @@ class Client(ClientV0):
         base_url = get_url(
             self.config["protocol"], self.tenant, self.config["site.domain"]
         )
+
+        if "machine_type" in kwargs["asset_selection"]:
+            # updating kwargs with machine_type's system name in case of user provides display name.
+            kwargs["asset_selection"][
+                "machine_type"
+            ] = self.get_machine_type_from_clean_name(kwargs)
+
+        if "machine_source" in kwargs["asset_selection"]:
+            # updating kwargs with machine_source's system name in case of user provides display name.
+            kwargs["asset_selection"][
+                "machine_source"
+            ] = self.get_machine_source_from_clean_name(kwargs)
+
         return kpi_entity(self.session, base_url).get_kpi_data_viz(**kwargs)
 
     def get_type_from_machine(self, machine_source=None, **kwargs):

--- a/tests/kpi/test_kpi.py
+++ b/tests/kpi/test_kpi.py
@@ -110,3 +110,63 @@ def test_kpi_for_asset_display_name(get_client):
     assert df2[0]["name"] in kpis
 
     assert df1 == df2
+
+
+def test_get_kpi_data_viz(get_client):
+    data_viz_query = {
+        "asset_selection": {
+            "machine_source": ["JB_NG_PickAndPlace_1_Stage6"],
+            "machine_type": ["PickAndPlace"],
+        },
+        "d_vars": [{"name": "quality", "aggregate": ["avg"]}],
+        "i_vars": [
+            {
+                "name": "endtime",
+                "time_resolution": "day",
+                "query_tz": "America/Los_Angeles",
+                "output_tz": "America/Los_Angeles",
+                "bin_strategy": "user_defined2",
+                "bin_count": 50,
+            }
+        ],
+        "time_selection": {
+            "time_type": "relative",
+            "relative_start": 7,
+            "relative_unit": "year",
+            "ctime_tz": "America/Los_Angeles",
+        },
+        "where": [],
+        "db_mode": "sql",
+    }
+
+    df1 = get_client.get_kpi_data_viz(**data_viz_query)
+
+    data_viz_query = {
+        "asset_selection": {
+            "machine_source": ["Nagoya - Pick and Place 6"],
+            "machine_type": ["Pick & Place"],
+        },
+        "d_vars": [{"name": "quality", "aggregate": ["avg"]}],
+        "i_vars": [
+            {
+                "name": "endtime",
+                "time_resolution": "day",
+                "query_tz": "America/Los_Angeles",
+                "output_tz": "America/Los_Angeles",
+                "bin_strategy": "user_defined2",
+                "bin_count": 50,
+            }
+        ],
+        "time_selection": {
+            "time_type": "relative",
+            "relative_start": 7,
+            "relative_unit": "year",
+            "ctime_tz": "America/Los_Angeles",
+        },
+        "where": [],
+        "db_mode": "sql",
+    }
+
+    df2 = get_client.get_kpi_data_viz(**data_viz_query)
+
+    assert len(df1) == len(df2)

--- a/tests/kpi/test_kpi.py
+++ b/tests/kpi/test_kpi.py
@@ -83,3 +83,30 @@ def test_get_kpi_data_viz(mocked):
     data = dt.get_kpi_data_viz()
     assert len(data) == 3
     assert data[0]["d_vals"]["quality"]["avg"] == 95.18072289156626
+
+
+def test_kpi_for_asset_display_name(get_client):
+    kpis = ["performance", "oee", "quality", "availability"]
+    # Query against machine type system name and machine source system name
+    query = {
+        "asset_selection": {
+            "machine_type": ["PickAndPlace"],
+            "machine_source": ["JB_NG_PickAndPlace_1_Stage6"],
+        }
+    }
+    df1 = get_client.get_kpis_for_asset(**query)
+    assert len(df1) > 0
+    assert df1[0]["name"] in kpis
+
+    # Query against machine type display name and machine source display name
+    query = {
+        "asset_selection": {
+            "machine_type": ["Pick & Place"],
+            "machine_source": ["Nagoya - Pick and Place 6"],
+        }
+    }
+    df2 = get_client.get_kpis_for_asset(**query)
+    assert len(df2) > 0
+    assert df2[0]["name"] in kpis
+
+    assert df1 == df2


### PR DESCRIPTION
Reference ticket- https://sightmachine.atlassian.net/browse/ENG-3270

Added support for clean name of machine_type and machine_source to accept both the values in get_kpi_for_asset() function in SDK.