### PR TITLE
ENG-3443: Fixed test_get_downtime unit failure

### DIFF
--- a/smsdk/ma_session.py
+++ b/smsdk/ma_session.py
@@ -44,7 +44,7 @@ class MaSession:
         self,
         endpoint: str,
         method: str = "get",
-        _limit: float = np.Inf,
+        _limit: int = np.Inf,
         _offset: int = 0,
         **url_params: t_.Any,
     ) -> t_.List[t_.Dict[str, t_.Any]]:

--- a/tests/downtime/test_downtime.py
+++ b/tests/downtime/test_downtime.py
@@ -10,7 +10,7 @@ MACHINE_TYPE = "Lasercut"
 MACHINE_INDEX = 0
 START_DATETIME = datetime(2023, 4, 1)
 END_DATETIME = datetime(2023, 4, 2)
-EXPECTED_ROWS = 18
+EXPECTED_ROWS = 136
 EXPECTED_COL = 8
 URL_V1 = "/v1/datatab/downtime"
 


### PR DESCRIPTION
The function `get_machine_names` returns machines in a sorted order when utilizing the 'V0' endpoint, yet they appear unsorted when using the 'V1' endpoint.

The discrepancy arises from employing distinct machines for the 'get_downtimes' operation in 'V0' and 'V1'. This results in receiving different record counts—18 and 136, respectively. To address this issue, I've modified the 'EXPECTED_ROWS' value.