### PR TITLE
Resolved extra whitespace from source clean

### DIFF
--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -287,7 +287,9 @@ class Client(ClientV0):
     def get_machine_type_from_clean_name(self, kwargs):
         # Get machine_types dataframe to check display name
         machine_types_df = self.get_machine_types()
-
+        machine_types_df["source_type_clean"] = machine_types_df[
+            "source_type_clean"
+        ].map(str.strip)
         # Creating lookup table against display_name:system_name from machine type dataframe.
         alias_tbl = (
             machine_types_df.loc[:, ["source_type", "source_type_clean"]]
@@ -305,6 +307,9 @@ class Client(ClientV0):
     def get_machine_source_from_clean_name(self, kwargs):
         # Get machines dataframe to check display/clean name
         machine_sources_df = self.get_machines()
+        machine_sources_df["source_clean"] = machine_sources_df["source_clean"].map(
+            str.strip
+        )
         alias_tbl = (
             machine_sources_df.loc[:, ["source", "source_clean"]]
             .set_index("source_clean")


### PR DESCRIPTION
There might be extra whitespaces in clean names in source or source_type
Resolved by mapping the strip method in dataframe.