### PR TITLE
Catch valueError when got incorrect machines

### DIFF
--- a/smsdk/ma_session.py
+++ b/smsdk/ma_session.py
@@ -102,6 +102,9 @@ class MaSession:
                     return records
                 _offset += this_loop_limit
 
+            except ValueError as e:
+                raise e
+
             except Exception as e:
                 # No need to raise an error as this will still continue execution.
                 print(f"Error getting data, but continuing. {e}")

--- a/tests/cycle/test_cycle.py
+++ b/tests/cycle/test_cycle.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from tests.conftest import TENANT
 from smsdk.smsdk_entities.cycle.cycleV1 import Cycle
 from tests.cycle.cycle_data import JSON_MACHINE_CYCLE_50
-
+import unittest
 
 # Define all the constants used in the test
 MACHINE_TYPE = "Lasercut"
@@ -60,6 +60,24 @@ def test_get_cycles(get_client):
     df = get_client.get_cycles(**query)
 
     assert df.shape == (NUM_ROWS, len(columns))
+
+
+def test_get_cycles_with_fake_source(get_client):
+    machines = get_client.get_machine_names(source_type=MACHINE_TYPE)
+    machine = machines[MACHINE_INDEX]
+    columns = get_client.get_machine_schema(machine)["display"].to_list()
+
+    query = {
+        "Machine": "fake_machine",
+        "End Time__gte": START_DATETIME,
+        "End Time__lte": END_DATETIME,
+        "_order_by": "-End Time",
+        "_limit": NUM_ROWS,
+        "_only": columns,
+    }
+    # ValueError is expected because of machine that does not exist.
+    with unittest.TestCase().assertRaises(ValueError) as context:
+        df = get_client.get_cycles(**query)
 
 
 def test_get_cycles_machine_tag(get_client):


### PR DESCRIPTION
- Added exceptions when handling incorrect machines.
- Added unit test to get value error when trying to call SDK functions for incorrect machines.