### PR TITLE
Migrated tenant for 'demo-sdk-test' to 'demo'

### DIFF
--- a/smsdk/const.py
+++ b/smsdk/const.py
@@ -1,3 +1,9 @@
-API_KEY = "5a73aa5a-1962-4df9-b56e-4a59462f0f00"
-API_SECRETE = "sma_FajgH3VbPu68gwy0PzccvhyGRyy1a8CCHhhvy6ooeg1O_"
-TENANT = "demo-sdk-test"
+import os
+
+API_KEY = os.environ.get("ENV_VAR_API_KEY")
+API_SECRET = os.environ.get("ENV_VAR_API_SECRET")
+TENANT = os.environ.get("ENV_VAR_TENANT")
+
+# Check if any of the required environment variables are not set
+if API_KEY is None or API_SECRET is None or TENANT is None:
+    raise EnvironmentError("One or more required environment variables are not set.")

--- a/smsdk/const.py
+++ b/smsdk/const.py
@@ -1,9 +1,0 @@
-import os
-
-API_KEY = os.environ.get("ENV_VAR_API_KEY")
-API_SECRET = os.environ.get("ENV_VAR_API_SECRET")
-TENANT = os.environ.get("ENV_VAR_TENANT")
-
-# Check if any of the required environment variables are not set
-if API_KEY is None or API_SECRET is None or TENANT is None:
-    raise EnvironmentError("One or more required environment variables are not set.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from smsdk import const
 # These values may change for each run.
 
 API_KEY = const.API_KEY
-API_SECRETE = const.API_SECRETE
+API_SECRET = const.API_SECRET
 
 TENANT = const.TENANT
 
@@ -21,6 +21,6 @@ def get_session():
 @pytest.fixture(scope="session")
 def get_client():
     cli = client.Client(TENANT)
-    cli.login("apikey", key_id=API_KEY, secret_id=API_SECRETE)
+    cli.login("apikey", key_id=API_KEY, secret_id=API_SECRET)
 
     return cli

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
+import os
 from smsdk import client
 from requests.sessions import Session
 import pytest
-from smsdk import const
 
-# Define all the constants used in the test
-# These values may change for each run.
+API_KEY = os.environ.get("ENV_VAR_API_KEY")
+API_SECRET = os.environ.get("ENV_VAR_API_SECRET")
+TENANT = os.environ.get("ENV_VAR_TENANT")
 
-API_KEY = const.API_KEY
-API_SECRET = const.API_SECRET
-
-TENANT = const.TENANT
+# Check if any of the required environment variables are not set
+if API_KEY is None or API_SECRET is None or TENANT is None:
+    raise EnvironmentError("One or more required environment variables are not set.")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
The tenant used for running the unit tests has been reverted back to 'demo' from 'demo-sdk-test'. This change enables us to delete the redundant environment and save costs.

From now onwards, the following environment variables need to be set for the successful execution of unit tests and ipynb.

List of environment variables:
1. ENV_VAR_API_KEY
2. ENV_VAR_API_SECRET
3. ENV_VAR_TENANT
4. ENV_VAR_USERNAME
5. ENV_VAR_PASSWORD

I have already updated the required environment values in Sightmachine's CircleCI Organization Settings > Context > org-sightmachine. 