### PR TITLE
ENG-4490: Setting default value for query param '_limit'.

### DIFF
--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -318,6 +318,7 @@ class ClientV0(object):
 
             if not "_limit" in kwargs:
                 print("_limit not specified.  Maximum of 5000 rows will be returned.")
+                kwargs["_limit"] = 5000
 
             if not "_only" in kwargs:
                 print("_only not specified.  Selecting first 50 fields.")


### PR DESCRIPTION
https://sightmachine.atlassian.net/browse/ENG-4490

The absence of the '_limit' parameter in the query dictionary resulted in a misleading log message indicating that '_limit' was set to 5000. However, in reality the parameter was left unset. Consequently, the limit was automatically set to the maximum possible value like 'np.Inf' before executing the SQL query. This led to Gateway Timeout-504 issues when attempting to fetch cycles from a DB with a large number of records. 

If the limit is not set in the dictionary, by programmatically setting it to 5000 resolved the Gateway timeout issues. Enabling smooth execution of the notebook at my end.

However, it needs to be addressed that if the user selects a very large value for '_limit' in the query itself, then the issue may reappear again.

