### PR TITLE
ENG-4849:get_machine_names doesn't error if machine type doesn't exist

### DIFF
--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -712,12 +712,9 @@ class Client(ClientV0):
         mts = self.get_data_v1("machine_type_v1", "get_machine_types", *args, **kwargs)
 
         if source_type is not None:
-            mts = mts[
-                np.logical_or(
-                    mts["source_type"] == source_type,
-                    mts["source_type_clean"] == source_type,
-                )
-            ]
+            mts = mts[mts["source_type"] == source_type]
+        if "source_type_clean" in kwargs and kwargs["source_type_clean"] is not None:
+            mts = mts[mts["source_type_clean"] == kwargs["source_type_clean"]]
 
         return mts
 

--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -711,10 +711,11 @@ class Client(ClientV0):
         """
         mts = self.get_data_v1("machine_type_v1", "get_machine_types", *args, **kwargs)
 
-        if source_type is not None:
+        if source_type:  # will not match empty string
             mts = mts[mts["source_type"] == source_type]
-        if "source_type_clean" in kwargs and kwargs["source_type_clean"] is not None:
-            mts = mts[mts["source_type_clean"] == kwargs["source_type_clean"]]
+        else:
+            if kwargs.get("source_type_clean"):
+                mts = mts[mts["source_type_clean"] == kwargs["source_type_clean"]]
 
         return mts
 


### PR DESCRIPTION
Link to Jira: https://sightmachine.atlassian.net/browse/ENG-4849


`get_machine_types` API is modified to utilize utilize both `source_type` and `source_type_clean` for filtering the data.