### PR TITLE
ENG-9025 migrate to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smsdk"
+authors = [
+    {name = "Sight Machine", email = "support@sightmachine.com"}
+]
+description = "Sight Machine SDK"
+requires-python = ">=3.8"
+dynamic = ["version", "dependencies", "readme"]
+
+[project.urls]
+Homepage = "http://sightmachine.com/"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "smsdk._version.version"}
+readme = {file = ["README.md"]}
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["test*"]

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,5 @@
-from setuptools import setup, find_packages
-from smsdk._version import version
+# retaining a minimal setup.py, but all configuration is in pyproject.toml
+# https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#what-if-something-that-can-not-be-changed-expects-a-setup-py-file
+from setuptools import setup
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-with open("requirements.txt", "r") as fh:
-    install_requires = [
-        line
-        for line in (item.strip() for item in fh)
-        if line and line[:1] not in ("#", "-")
-    ]
-
-setup(
-    name="smsdk",
-    version=version,
-    packages=find_packages(exclude=["test*"]),
-    include_package_data=True,
-    install_requires=install_requires,
-    license="",
-    long_description=long_description,
-    author="Sight Machine",
-    author_email="support@sightmachine.com",
-    url="http://sightmachine.com/",
-    description="Sight Machine SDK",
-    python_requires=">=3.8",
-)
+setup()


### PR DESCRIPTION
Migrating from `setup.py` to `pyproject.toml` due to support dropping from pip.