### PR TITLE
ENG-9909 add support for path-based multi-tenancy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
             pip install -r requirements-codecoverage.txt
             pip install .
             mkdir test-results
-            coverage run -m pytest -vvv --nbmake --nbmake-timeout=300 -n=auto --junitxml=test-results/junit.xml tests
+            pytest -vvv --nbmake --nbmake-timeout=300 -n=auto --cov=smsdk --cov-config=.coveragerc --cov-report= --junitxml=test-results/junit.xml tests
 
       # Store the test results on each node so we can see failures
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-workflows: 
+workflows:
   code-commit:
     jobs:
       - black-python-code-formatter:
@@ -9,6 +9,10 @@ workflows:
           context: org-sightmachine
       - run-unit-tests:
           context: org-sightmachine
+      - code-coverage-report:
+          context: org-sightmachine
+          requires:
+            - run-unit-tests
       - cve-repo-scan:
           context: org-sightmachine
   nightly-cve:
@@ -129,21 +133,52 @@ jobs:
             pip install .
             mkdir test-results
             coverage run -m pytest -vvv --nbmake --nbmake-timeout=300 -n=auto --junitxml=test-results/junit.xml tests
-      - run:
-          name: Compile Coverage Report
-          command: |
-            coverage html -d htmlcov
-            codecov --required
 
       # Store the test results on each node so we can see failures
       - store_test_results:
           path: test-results
-      
+
       - store_artifacts:
           name: Save Unit Test Results
-          path: htmlcov
+          path: test-results
 
-      - send_slack_msg_on_fail    
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .coverage
+
+      - send_slack_msg_on_fail
+
+  ## ------------------ Generate Code Coverage Report ------------------
+
+  code-coverage-report:
+    docker:
+      # https://circleci.com/developer/images/image/cimg/python
+      - image: cimg/python:3.11.0
+    steps:
+      # Coverage html requires source code to build HTML views
+      - checkout
+      # Need workspace for the coverage report
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Compile Coverage Report
+          command: |
+            set -x
+            pip install -r requirements-codecoverage.txt
+            # Check if coverage file exists before generating report
+            if [ -f /tmp/workspace/.coverage ]; then
+              cp /tmp/workspace/.coverage .
+              coverage html -d htmlcov
+            else
+              echo "No coverage file found. Skipping coverage report generation."
+              mkdir -p htmlcov
+              echo "<html><body><h1>No coverage data available</h1></body></html>" > htmlcov/index.html
+            fi
+      - store_artifacts:
+          name: Save Coverage Report
+          path: htmlcov/
+      - codecov/upload
 
   ## ------------------ Check Black python code formate ------------------
   black-python-code-formatter:

--- a/README.md
+++ b/README.md
@@ -29,13 +29,33 @@ When accessing Sight Machine via the SDK, the first step is always to initialize
 will point to the name of the tenant on Sight Machine.  For example, if you access Sight Machine at the URL *mycompany*.sightmachine.io, then *mycompany* is 
 the name of the tenant you will use. For purposes of this Quick Start documentation, we will use demo as the tenant name.
 
-To initialize a Client: 
+To initialize a Client:
 
 ```
 from smsdk import client
 tenant = 'demo'
 cli = client.Client(tenant)
 ```
+
+#### Nested Path Support
+
+For deployments where Sight Machine is hosted under a nested path (e.g., `https://tenant.sightmachine.io/nested/one/two/`), you can specify the base path in two ways:
+
+**Method 1: Explicit base_path parameter**
+```python
+cli = client.Client('demo', base_path='/nested/one/two')
+```
+
+**Method 2: Include path in tenant URL**
+```python
+cli = client.Client('https://demo.sightmachine.io/nested/one/two')
+```
+
+The SDK will automatically construct URLs with the correct path prefix for all API calls. For example:
+- Without path: `https://demo.sightmachine.io/v1/datatab/cycle`
+- With path: `https://demo.sightmachine.io/nested/one/two/v1/datatab/cycle`
+
+**Note:** The `base_path` parameter takes precedence if both methods are used.
 
 ### Authenticating
 

--- a/requirements-codecoverage.txt
+++ b/requirements-codecoverage.txt
@@ -3,4 +3,5 @@
 codecov==2.1.13
 coverage==7.3.2
 nbmake==1.4.6
+pytest-cov==4.1.0
 pytest-xdist==3.5.0

--- a/smsdk/Auth/auth.py
+++ b/smsdk/Auth/auth.py
@@ -48,6 +48,7 @@ class Authenticator(MaSession):
             client.tenant,
             client.config["site.domain"],
             client.config["port"],
+            client.config.get("base.path"),
         )
         self.session.headers = default_headers()
 

--- a/smsdk/client.py
+++ b/smsdk/client.py
@@ -6,6 +6,7 @@ from smsdk.version_utils import version_check_decorator
 
 import pandas as pd
 import numpy as np
+import typing as t_
 
 try:
     # for newer pandas versions >1.X
@@ -128,7 +129,11 @@ class Client(ClientV0):
     """Connection point to the Sight Machine platform to retrieve data"""
 
     def __init__(
-        self, tenant: str, site_domain: str = "sightmachine.io", protocol: str = "https"
+        self,
+        tenant: str,
+        site_domain: str = "sightmachine.io",
+        protocol: str = "https",
+        base_path: t_.Optional[str] = None,
     ):
         """
         Initialize the client.
@@ -139,9 +144,15 @@ class Client(ClientV0):
             The site domain to connect to. Necessary to change if deploying in
             a non-standard environment.
         :type site_domain: :class:`string`
+        :param protocol: Protocol to use (https or http).
+        :type protocol: :class:`string`
+        :param base_path: Optional path prefix for nested deployments (e.g., "/nested/one/two")
+        :type base_path: :class:`string` or None
         """
 
-        super().__init__(tenant, site_domain=site_domain, protocol=protocol)
+        super().__init__(
+            tenant, site_domain=site_domain, protocol=protocol, base_path=base_path
+        )
 
     @version_check_decorator
     def select_db_schema(self, schema_name):
@@ -176,6 +187,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
 
         df = pd.DataFrame()
@@ -292,6 +304,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return kpis(self.session, base_url).get_kpis(**kwargs)
 
@@ -345,6 +358,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         if "machine_type" in kwargs["asset_selection"]:
             # updating kwargs with machine_type's system name in case of user provides display name.
@@ -394,6 +408,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
 
         if "asset_selection" in kwargs and "machine_type" in kwargs["asset_selection"]:
@@ -419,6 +434,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return machine(self.session, base_url).get_type_from_machine_name(
             machine_source, **kwargs
@@ -440,6 +456,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         fields = machineType(self.session, base_url).get_fields(machine_type, **kwargs)
         fields = [
@@ -479,6 +496,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         fields = machineType(self.session, base_url).get_fields(machine_type, **kwargs)
         fields = [
@@ -505,6 +523,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return cookbook(self.session, base_url).get_cookbooks(**kwargs)
 
@@ -522,6 +541,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return cookbook(self.session, base_url).get_top_results(
             recipe_group_id, limit, **kwargs
@@ -541,6 +561,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return cookbook(self.session, base_url).get_current_value(
             variables, minutes, **kwargs
@@ -582,6 +603,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         return lines(self.session, base_url).get_lines(**kwargs)
 
@@ -613,6 +635,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
 
         asset_selection = []
@@ -664,6 +687,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
 
         if i_vars:
@@ -707,6 +731,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         if assets and model == "cycle" or assets and model == "kpi":
             machine_types = []
@@ -851,6 +876,7 @@ class Client(ClientV0):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         select = [{"name": field} for field in fields]
         kwargs["asset_selection"] = {"raw_data_table": raw_data_table}

--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -81,9 +81,9 @@ def convert_to_valid_url(
     input_url: str,
     default_domain: str = "sightmachine.io",
     default_protocol: str = "https",
-):
+) -> t_.Tuple[str, t_.Optional[str]]:
     port = ""
-    path = ""
+    path = None
 
     # Check if the input URL has a protocol specified
     if "://" in input_url:
@@ -100,9 +100,14 @@ def convert_to_valid_url(
 
     if len(parts) == 1:
         domain = parts[0]
-        path = ""
+        path = None
     else:
         domain, path = parts
+        # Only keep path if it's not empty after stripping
+        if path and path.strip():
+            path = "/" + path.rstrip("/")
+        else:
+            path = None
 
     # Check if the domain has a port specified
     splits = domain.split(":", 1)
@@ -125,11 +130,7 @@ def convert_to_valid_url(
         valid_url = f"{valid_url}:{port}"
         # log.warning(f"Ignored the user specified port.")
 
-    if path:
-        # valid_url = f"{valid_url}/{path}"
-        log.warning(f"Ignored the user specified path.")
-
-    return valid_url
+    return valid_url, path
 
 
 # We don't have a downtime schema, so hard code one
@@ -164,7 +165,11 @@ class ClientV0(object):
     config = {}
 
     def __init__(
-        self, tenant: str, site_domain: str = "sightmachine.io", protocol: str = "https"
+        self,
+        tenant: str,
+        site_domain: str = "sightmachine.io",
+        protocol: str = "https",
+        base_path: t_.Optional[str] = None,
     ):
         """
         Initialize the client.
@@ -175,17 +180,22 @@ class ClientV0(object):
             The site domain to connect to. Necessary to change if deploying in
             a non-standard environment.
         :type site_domain: :class:`string`
+        :param protocol: Protocol to use (https or http).
+        :type protocol: :class:`string`
+        :param base_path: Optional path prefix for nested deployments (e.g., "/nested/one/two")
+        :type base_path: :class:`string` or None
         """
 
         port = None
+        extracted_path = None
         if tenant:
-            # Convert the input tenant into a valid url
-            url = convert_to_valid_url(
+            # Convert the input tenant into a valid url and extract any path
+            url_without_path, extracted_path = convert_to_valid_url(
                 tenant, default_domain=site_domain, default_protocol=protocol
             )
 
-            # Parse the input string
-            parsed_uri = urlparse(url)
+            # Parse the input string (now without path)
+            parsed_uri = urlparse(url_without_path)
 
             tenant = parsed_uri.netloc.split(".", 1)[0]
             protocol = parsed_uri.scheme
@@ -194,8 +204,16 @@ class ClientV0(object):
             # Extract port
             port = parsed_uri.port
 
+        # Determine final base_path: explicit param takes precedence over extracted
+        final_base_path = base_path if base_path is not None else extracted_path
+
         self.tenant = tenant
-        self.config = {"protocol": protocol, "site.domain": site_domain, "port": port}
+        self.config = {
+            "protocol": protocol,
+            "site.domain": site_domain,
+            "port": port,
+            "base.path": final_base_path,
+        }
 
         # Setup Authenticator
         self.auth = Authenticator(self)
@@ -280,6 +298,7 @@ class ClientV0(object):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
 
         df = pd.DataFrame()
@@ -1492,6 +1511,7 @@ class ClientV0(object):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         cls = smsdkentities.get("dataviz_cycle")(self.session, base_url)
 
@@ -1606,6 +1626,7 @@ class ClientV0(object):
             self.tenant,
             self.config["site.domain"],
             self.config["port"],
+            self.config.get("base.path"),
         )
         cls = smsdkentities.get("dataviz_part")(self.session, base_url)
 

--- a/smsdk/client_v0.py
+++ b/smsdk/client_v0.py
@@ -1033,7 +1033,7 @@ class ClientV0(object):
 
         stats = all_parts.loc[
             (all_parts.part_type == pt) | (all_parts.part_type_clean == pt), "stats"
-        ][0]
+        ].iloc[0]
 
         for machine in stats.keys():
             m_stats = stats[machine]

--- a/smsdk/utils.py
+++ b/smsdk/utils.py
@@ -21,7 +21,11 @@ module_utility = ModuleUtility
 
 
 def get_url(
-    protocol: str, tenant: str, site_domain: str, port: t_.Optional[int] = None
+    protocol: str,
+    tenant: str,
+    site_domain: str,
+    port: t_.Optional[int] = None,
+    base_path: t_.Optional[str] = None,
 ) -> str:
     """
     Get the URL of the web address.
@@ -34,6 +38,8 @@ def get_url(
     :type site_domain: :class:`string`
     :param port: The port number (defaults to None).
     :type port: :Int
+    :param base_path: Optional path prefix for nested deployments (e.g., "/nested/one/two")
+    :type base_path: :class:`string` or None
     """
 
     url = ""
@@ -42,5 +48,14 @@ def get_url(
         url = f"{protocol}://{tenant}.{site_domain}:{port}"
     else:
         url = f"{protocol}://{tenant}.{site_domain}"
+
+    # Add base_path if provided
+    if base_path:
+        # Normalize: ensure starts with / but doesn't end with /
+        normalized_path = base_path.strip()
+        if not normalized_path.startswith("/"):
+            normalized_path = "/" + normalized_path
+        normalized_path = normalized_path.rstrip("/")
+        url = f"{url}{normalized_path}"
 
     return url

--- a/tests/Uri/test_uri.py
+++ b/tests/Uri/test_uri.py
@@ -120,3 +120,161 @@ def test_create_client_uri_special_cases() -> None:
     assert (
         cli.config["site.domain"] == "localnet.sightmachine.io"
     ), "Site domain should be set to localnet"
+
+
+def test_create_client_with_explicit_base_path() -> None:
+    """Test explicit base_path parameter"""
+    tenant = "demo"
+    cli = client.Client(tenant, base_path="/nested/one/two")
+
+    assert cli.tenant == "demo", "Tenant should be initialized correctly"
+    assert cli.config["base.path"] == "/nested/one/two", "Base path should be set"
+    assert cli.config["protocol"] == "https", "Protocol should be set to HTTPS"
+    assert (
+        cli.config["site.domain"] == "sightmachine.io"
+    ), "Site domain should be set to sightmachine.io"
+
+    # Verify URL construction includes path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert (
+        url == "https://demo.sightmachine.io/nested/one/two"
+    ), "URL should include nested path"
+
+
+def test_create_client_with_url_including_path() -> None:
+    """Test path extraction from tenant URL"""
+    tenant = "https://demo.sightmachine.io/nested/one/two"
+    cli = client.Client(tenant)
+
+    assert cli.tenant == "demo", "Tenant should be extracted correctly"
+    assert cli.config["base.path"] == "/nested/one/two", "Path should be extracted"
+    assert cli.config["protocol"] == "https", "Protocol should be set to HTTPS"
+    assert (
+        cli.config["site.domain"] == "sightmachine.io"
+    ), "Site domain should be set to sightmachine.io"
+
+    # Verify URL construction includes path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert (
+        url == "https://demo.sightmachine.io/nested/one/two"
+    ), "URL should include nested path"
+
+
+def test_create_client_explicit_path_overrides_extracted() -> None:
+    """Explicit base_path should override extracted path"""
+    tenant = "https://demo.sightmachine.io/old/path"
+    cli = client.Client(tenant, base_path="/new/path")
+
+    assert cli.tenant == "demo", "Tenant should be extracted correctly"
+    assert (
+        cli.config["base.path"] == "/new/path"
+    ), "Explicit path should override extracted path"
+    assert cli.config["protocol"] == "https", "Protocol should be set to HTTPS"
+
+    # Verify URL construction uses explicit path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert (
+        url == "https://demo.sightmachine.io/new/path"
+    ), "URL should use explicit path"
+
+
+def test_backward_compatibility_no_path() -> None:
+    """Existing behavior without path should work unchanged"""
+    tenant = "demo"
+    cli = client.Client(tenant)
+
+    assert cli.tenant == "demo", "Tenant should be initialized correctly"
+    assert cli.config.get("base.path") is None, "Base path should be None by default"
+    assert cli.config["protocol"] == "https", "Protocol should be set to HTTPS"
+    assert (
+        cli.config["site.domain"] == "sightmachine.io"
+    ), "Site domain should be set to sightmachine.io"
+
+    # Verify URL construction works without path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert url == "https://demo.sightmachine.io", "URL should not include any path"
+
+
+def test_create_client_with_path_and_port() -> None:
+    """Test base_path with custom port"""
+    tenant = "http://demo.sightmachine.io:8080/nested/path"
+    cli = client.Client(tenant)
+
+    assert cli.tenant == "demo", "Tenant should be extracted correctly"
+    assert cli.config["base.path"] == "/nested/path", "Path should be extracted"
+    assert cli.config["protocol"] == "http", "Protocol should be set to HTTP"
+    assert cli.config["port"] == 8080, "Port should be set to 8080"
+    assert (
+        cli.config["site.domain"] == "sightmachine.io"
+    ), "Site domain should be set to sightmachine.io"
+
+    # Verify URL construction includes both port and path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert (
+        url == "http://demo.sightmachine.io:8080/nested/path"
+    ), "URL should include port and path"
+
+
+def test_create_client_with_trailing_slash_in_path() -> None:
+    """Test that trailing slashes in paths are normalized"""
+    tenant = "https://demo.sightmachine.io/nested/path/"
+    cli = client.Client(tenant)
+
+    assert cli.tenant == "demo", "Tenant should be extracted correctly"
+    assert (
+        cli.config["base.path"] == "/nested/path"
+    ), "Trailing slash should be removed"
+
+    # Verify URL construction normalizes path
+    from smsdk.utils import get_url
+
+    url = get_url(
+        cli.config["protocol"],
+        cli.tenant,
+        cli.config["site.domain"],
+        cli.config["port"],
+        cli.config.get("base.path"),
+    )
+    assert (
+        url == "https://demo.sightmachine.io/nested/path"
+    ), "URL should have normalized path"

--- a/tests/Uri/test_uri.py
+++ b/tests/Uri/test_uri.py
@@ -261,9 +261,7 @@ def test_create_client_with_trailing_slash_in_path() -> None:
     cli = client.Client(tenant)
 
     assert cli.tenant == "demo", "Tenant should be extracted correctly"
-    assert (
-        cli.config["base.path"] == "/nested/path"
-    ), "Trailing slash should be removed"
+    assert cli.config["base.path"] == "/nested/path", "Trailing slash should be removed"
 
     # Verify URL construction normalizes path
     from smsdk.utils import get_url

--- a/tests/cycle/test_cycle.py
+++ b/tests/cycle/test_cycle.py
@@ -9,8 +9,8 @@ from smsdk.custom_exception.errors import NotFound
 # Define all the constants used in the test
 MACHINE_TYPE = "Lasercut"
 MACHINE_INDEX = 5
-START_DATETIME = datetime(2023, 4, 1)
-END_DATETIME = datetime(2023, 4, 2)
+START_DATETIME = datetime(2026, 3, 1)
+END_DATETIME = datetime(2026, 3, 2)
 NUM_ROWS = 500
 URL_V1 = "/v1/datatab/cycle"
 
@@ -57,6 +57,8 @@ def test_get_cycles(get_client):
         "_limit": NUM_ROWS,
         "_only": columns,
     }
+
+    # breakpoint()
 
     df = get_client.get_cycles(**query)
 

--- a/tests/downtime/test_downtime.py
+++ b/tests/downtime/test_downtime.py
@@ -8,9 +8,9 @@ from tests.downtime.downtime_data import JSON_MACHINE_DOWNTIME_100
 # Define all the constants used in the test
 MACHINE_TYPE = "Lasercut"
 MACHINE_INDEX = 0
-START_DATETIME = datetime(2023, 4, 1)
-END_DATETIME = datetime(2023, 4, 2)
-EXPECTED_ROWS = 18
+START_DATETIME = datetime(2026, 3, 1)
+END_DATETIME = datetime(2026, 3, 2)
+EXPECTED_ROWS = 11
 EXPECTED_COL = 8
 URL_V1 = "/v1/datatab/downtime"
 

--- a/tests/lines/test_line.py
+++ b/tests/lines/test_line.py
@@ -19,7 +19,7 @@ MACHINE4 = "JB_NG_PickAndPlace_1_Stage4"
 FIELD_NAME1 = "stats__BLOCKED__val"
 FIELD_NAME2 = "stats__PneumaticPressure__val"
 MIN_PRESSURE = 75.25
-EXP_NUM_ROWS = 3
+EXP_NUM_ROWS = 7
 URL_V1 = "/v1/datatab/line"
 
 

--- a/tests/lines/test_line.py
+++ b/tests/lines/test_line.py
@@ -7,8 +7,8 @@ from tests.lines.line_data import AVALIBLE_LINE_JSON, LINE_DATA_JSON
 
 
 # # Define all the constants used in the test
-START_DATETIME = "2023-04-01T08:00:00.000Z"
-END_DATETIME = "2023-04-02T23:00:00.000Z"
+START_DATETIME = "2026-03-01T08:00:00.000Z"
+END_DATETIME = "2026-03-02T23:00:00.000Z"
 TIME_ZONE = "America/Los_Angeles"
 MAX_ROWS = 50
 LINE_INDEX = 0
@@ -19,7 +19,7 @@ MACHINE4 = "JB_NG_PickAndPlace_1_Stage4"
 FIELD_NAME1 = "stats__BLOCKED__val"
 FIELD_NAME2 = "stats__PneumaticPressure__val"
 MIN_PRESSURE = 75.25
-EXP_NUM_ROWS = 14
+EXP_NUM_ROWS = 3
 URL_V1 = "/v1/datatab/line"
 
 

--- a/tests/machine/test_machine.py
+++ b/tests/machine/test_machine.py
@@ -235,7 +235,7 @@ def test_get_machine_schema(get_client):
 
     # Run
     df = get_client.get_machine_schema(machine)
-    assert df.shape == (36, 15)
+    assert df.shape == (38, 15)
 
     # Run
     df = get_client.get_machine_schema(machine, types)

--- a/tests/machine_type/test_machine_type.py
+++ b/tests/machine_type/test_machine_type.py
@@ -105,31 +105,33 @@ This test is against the demo-sdk-test environment and if the environment is cha
 def test_get_machines_types(get_client):
     machine_types = get_client.get_machine_types()
     unique_machine_types = machine_types["source_type"].dropna().unique()
-    assert unique_machine_types.tolist() == MACHINE_TYPE_NAMES_INTERNAL_EXPECT
+    assert sorted(unique_machine_types.tolist()) == sorted(
+        MACHINE_TYPE_NAMES_INTERNAL_EXPECT
+    )
 
     query = {
         "source_type": "Lasercut",
     }
 
     machine_types = get_client.get_machine_types(**query)
-    assert machine_types.shape == (29, 25)
+    assert machine_types.shape == (45, 27)
 
 
 def test_get_machines_types_v1(get_client):
     machine_types = get_client.get_machine_types()
-    assert machine_types.shape == (114, 25)
+    assert machine_types.shape == (178, 27)
 
 
 def test_get_machines_type_names_v1(get_client):
     machine_types_ui_based = get_client.get_machine_type_names()
-    assert machine_types_ui_based == MACHINE_TYPE_NAMES_UI_BASED_EXPECT
+    assert sorted(machine_types_ui_based) == sorted(MACHINE_TYPE_NAMES_UI_BASED_EXPECT)
 
     query = {
         "clean_strings_out": False,
     }
 
     machine_types_internal = get_client.get_machine_type_names(**query)
-    assert machine_types_internal == MACHINE_TYPE_NAMES_INTERNAL_EXPECT
+    assert sorted(machine_types_internal) == sorted(MACHINE_TYPE_NAMES_INTERNAL_EXPECT)
 
 
 def test_get_fields_of_machine_type(get_client):
@@ -138,7 +140,7 @@ def test_get_fields_of_machine_type(get_client):
 
     # Run
     fields = get_client.get_fields_of_machine_type(machine_type)
-    assert len(fields) == 36
+    assert len(fields) == 38
 
     # Run
     fields = get_client.get_fields_of_machine_type(machine_type, types)

--- a/tests/parts/test_part.py
+++ b/tests/parts/test_part.py
@@ -8,11 +8,17 @@ from smsdk.smsdk_entities.parts.partsV1 import Parts
 # Define all the constants used in the test
 MACHINE_TYPE = "Lasercut"
 PART_TYPE_INDEX = 1
-START_DATETIME = datetime(2023, 4, 1)
-END_DATETIME = datetime(2023, 4, 2)
+START_DATETIME = datetime(2026, 3, 1)
+END_DATETIME = datetime(2026, 3, 2)
 NUM_ROWS = 10
-NUM_COLUMNS_FOR_QUERY = 31
+NUM_COLUMNS_FOR_QUERY = 28
 URL_V1 = "/v1/datatab/part"
+
+# These columns have never been selectable for datatab parts queries since moving to Postgres
+INVALID_PART_TYPE_COLUMNS = [
+    "Output",
+    "Machine Sources",
+]
 
 
 def test_get_utilities(get_session):
@@ -82,6 +88,7 @@ def test_get_parts(get_client):
     part_type = part_types[PART_TYPE_INDEX]
 
     columns = get_client.get_part_schema(part_type)["display"].to_list()
+    columns = [col for col in columns if col not in INVALID_PART_TYPE_COLUMNS]
 
     query = {
         "Part": part_type,
@@ -89,7 +96,7 @@ def test_get_parts(get_client):
         "End Time__lte": END_DATETIME,
         "DefectReason__exists": True,
         "_limit": NUM_ROWS,
-        "_only": columns[: NUM_COLUMNS_FOR_QUERY - 1],
+        "_only": columns[:NUM_COLUMNS_FOR_QUERY],
     }
 
     df = get_client.get_parts(**query)

--- a/tests/raw_data/test_raw_data.py
+++ b/tests/raw_data/test_raw_data.py
@@ -24,8 +24,8 @@ def test_get_raw_data(get_client):
     select = []
     timeselection = {
         "time_type": "absolute",
-        "start_time": "2023-10-18T18:30:00.000Z",
-        "end_time": "2023-10-19T18:29:59.999Z",
+        "start_time": "2026-3-18T18:30:00.000Z",
+        "end_time": "2026-3-19T18:29:59.999Z",
         "time_zone": "America/Los_Angeles",
     }
     limit = 100

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Unit tests for URL utility functions"""
+
+import pytest
+from smsdk.utils import get_url
+from smsdk.client_v0 import convert_to_valid_url
+
+
+class TestGetUrl:
+    """Test cases for get_url() function"""
+
+    def test_get_url_without_path(self):
+        """Existing behavior - no path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path=None,
+        )
+        assert url == "https://demo.sightmachine.io"
+
+    def test_get_url_with_path(self):
+        """New behavior - with path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="/nested/one/two",
+        )
+        assert url == "https://demo.sightmachine.io/nested/one/two"
+
+    def test_get_url_with_path_trailing_slash_removed(self):
+        """Path normalization - trailing slash removed"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="/nested/one/two/",
+        )
+        assert url == "https://demo.sightmachine.io/nested/one/two"
+
+    def test_get_url_with_path_leading_slash_added(self):
+        """Path normalization - leading slash added"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="nested/one/two",
+        )
+        assert url == "https://demo.sightmachine.io/nested/one/two"
+
+    def test_get_url_with_path_both_slashes_normalized(self):
+        """Path normalization - both leading and trailing"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="nested/one/two/",
+        )
+        assert url == "https://demo.sightmachine.io/nested/one/two"
+
+    def test_get_url_with_port_and_path(self):
+        """Port and path together"""
+        url = get_url(
+            protocol="http",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=8080,
+            base_path="/nested",
+        )
+        assert url == "http://demo.sightmachine.io:8080/nested"
+
+    def test_get_url_with_port_no_path(self):
+        """Port without path - existing behavior"""
+        url = get_url(
+            protocol="http",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=8080,
+            base_path=None,
+        )
+        assert url == "http://demo.sightmachine.io:8080"
+
+    def test_get_url_with_empty_string_path(self):
+        """Empty string path treated as no path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="",
+        )
+        assert url == "https://demo.sightmachine.io"
+
+    def test_get_url_with_whitespace_path(self):
+        """Whitespace-only path treated as no path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="   ",
+        )
+        assert url == "https://demo.sightmachine.io"
+
+    def test_get_url_with_single_level_path(self):
+        """Single level nested path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="/nested",
+        )
+        assert url == "https://demo.sightmachine.io/nested"
+
+    def test_get_url_with_deep_nested_path(self):
+        """Deep nested path"""
+        url = get_url(
+            protocol="https",
+            tenant="demo",
+            site_domain="sightmachine.io",
+            port=None,
+            base_path="/a/b/c/d/e",
+        )
+        assert url == "https://demo.sightmachine.io/a/b/c/d/e"
+
+
+class TestConvertToValidUrl:
+    """Test cases for convert_to_valid_url() function"""
+
+    def test_convert_to_valid_url_extracts_path(self):
+        """Extract path from input URL"""
+        url, path = convert_to_valid_url("https://demo.sightmachine.io/nested/one/two")
+        assert url == "https://demo.sightmachine.io"
+        assert path == "/nested/one/two"
+
+    def test_convert_to_valid_url_no_path(self):
+        """No path in URL"""
+        url, path = convert_to_valid_url("demo")
+        assert url == "https://demo.sightmachine.io"
+        assert path is None
+
+    def test_convert_to_valid_url_with_protocol_no_path(self):
+        """Full URL without path"""
+        url, path = convert_to_valid_url("https://demo.sightmachine.io")
+        assert url == "https://demo.sightmachine.io"
+        assert path is None
+
+    def test_convert_to_valid_url_extracts_trailing_slash_normalized(self):
+        """Extract path with trailing slash - normalized"""
+        url, path = convert_to_valid_url("https://demo.sightmachine.io/nested/one/two/")
+        assert url == "https://demo.sightmachine.io"
+        assert path == "/nested/one/two"
+
+    def test_convert_to_valid_url_with_port_and_path(self):
+        """Extract path with port specified"""
+        url, path = convert_to_valid_url("https://demo.sightmachine.io:8080/nested/path")
+        assert url == "https://demo.sightmachine.io:8080"
+        assert path == "/nested/path"
+
+    def test_convert_to_valid_url_simple_tenant_with_custom_domain(self):
+        """Simple tenant with custom domain"""
+        url, path = convert_to_valid_url("demo", default_domain="custom.io")
+        assert url == "https://demo.custom.io"
+        assert path is None
+
+    def test_convert_to_valid_url_http_protocol(self):
+        """HTTP protocol instead of HTTPS"""
+        url, path = convert_to_valid_url("http://demo.sightmachine.io/nested")
+        assert url == "http://demo.sightmachine.io"
+        assert path == "/nested"
+
+    def test_convert_to_valid_url_empty_path(self):
+        """URL with trailing slash but no actual path"""
+        url, path = convert_to_valid_url("https://demo.sightmachine.io/")
+        assert url == "https://demo.sightmachine.io"
+        assert path is None
+
+    def test_convert_to_valid_url_single_level_path(self):
+        """Single level path extraction"""
+        url, path = convert_to_valid_url("demo.sightmachine.io/api")
+        assert url == "https://demo.sightmachine.io"
+        assert path == "/api"
+
+    def test_convert_to_valid_url_adds_default_domain(self):
+        """Adds default domain when not present"""
+        url, path = convert_to_valid_url("demo/nested/path")
+        assert url == "https://demo.sightmachine.io"
+        assert path == "/nested/path"

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -10,7 +10,7 @@ from smsdk.client_v0 import convert_to_valid_url
 class TestGetUrl:
     """Test cases for get_url() function"""
 
-    def test_get_url_without_path(self):
+    def test_get_url_without_path(self) -> None:
         """Existing behavior - no path"""
         url = get_url(
             protocol="https",
@@ -21,7 +21,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io"
 
-    def test_get_url_with_path(self):
+    def test_get_url_with_path(self) -> None:
         """New behavior - with path"""
         url = get_url(
             protocol="https",
@@ -32,7 +32,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io/nested/one/two"
 
-    def test_get_url_with_path_trailing_slash_removed(self):
+    def test_get_url_with_path_trailing_slash_removed(self) -> None:
         """Path normalization - trailing slash removed"""
         url = get_url(
             protocol="https",
@@ -43,7 +43,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io/nested/one/two"
 
-    def test_get_url_with_path_leading_slash_added(self):
+    def test_get_url_with_path_leading_slash_added(self) -> None:
         """Path normalization - leading slash added"""
         url = get_url(
             protocol="https",
@@ -54,7 +54,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io/nested/one/two"
 
-    def test_get_url_with_path_both_slashes_normalized(self):
+    def test_get_url_with_path_both_slashes_normalized(self) -> None:
         """Path normalization - both leading and trailing"""
         url = get_url(
             protocol="https",
@@ -65,7 +65,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io/nested/one/two"
 
-    def test_get_url_with_port_and_path(self):
+    def test_get_url_with_port_and_path(self) -> None:
         """Port and path together"""
         url = get_url(
             protocol="http",
@@ -76,7 +76,7 @@ class TestGetUrl:
         )
         assert url == "http://demo.sightmachine.io:8080/nested"
 
-    def test_get_url_with_port_no_path(self):
+    def test_get_url_with_port_no_path(self) -> None:
         """Port without path - existing behavior"""
         url = get_url(
             protocol="http",
@@ -87,7 +87,7 @@ class TestGetUrl:
         )
         assert url == "http://demo.sightmachine.io:8080"
 
-    def test_get_url_with_empty_string_path(self):
+    def test_get_url_with_empty_string_path(self) -> None:
         """Empty string path treated as no path"""
         url = get_url(
             protocol="https",
@@ -98,7 +98,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io"
 
-    def test_get_url_with_whitespace_path(self):
+    def test_get_url_with_whitespace_path(self) -> None:
         """Whitespace-only path treated as no path"""
         url = get_url(
             protocol="https",
@@ -109,7 +109,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io"
 
-    def test_get_url_with_single_level_path(self):
+    def test_get_url_with_single_level_path(self) -> None:
         """Single level nested path"""
         url = get_url(
             protocol="https",
@@ -120,7 +120,7 @@ class TestGetUrl:
         )
         assert url == "https://demo.sightmachine.io/nested"
 
-    def test_get_url_with_deep_nested_path(self):
+    def test_get_url_with_deep_nested_path(self) -> None:
         """Deep nested path"""
         url = get_url(
             protocol="https",
@@ -135,61 +135,63 @@ class TestGetUrl:
 class TestConvertToValidUrl:
     """Test cases for convert_to_valid_url() function"""
 
-    def test_convert_to_valid_url_extracts_path(self):
+    def test_convert_to_valid_url_extracts_path(self) -> None:
         """Extract path from input URL"""
         url, path = convert_to_valid_url("https://demo.sightmachine.io/nested/one/two")
         assert url == "https://demo.sightmachine.io"
         assert path == "/nested/one/two"
 
-    def test_convert_to_valid_url_no_path(self):
+    def test_convert_to_valid_url_no_path(self) -> None:
         """No path in URL"""
         url, path = convert_to_valid_url("demo")
         assert url == "https://demo.sightmachine.io"
         assert path is None
 
-    def test_convert_to_valid_url_with_protocol_no_path(self):
+    def test_convert_to_valid_url_with_protocol_no_path(self) -> None:
         """Full URL without path"""
         url, path = convert_to_valid_url("https://demo.sightmachine.io")
         assert url == "https://demo.sightmachine.io"
         assert path is None
 
-    def test_convert_to_valid_url_extracts_trailing_slash_normalized(self):
+    def test_convert_to_valid_url_extracts_trailing_slash_normalized(self) -> None:
         """Extract path with trailing slash - normalized"""
         url, path = convert_to_valid_url("https://demo.sightmachine.io/nested/one/two/")
         assert url == "https://demo.sightmachine.io"
         assert path == "/nested/one/two"
 
-    def test_convert_to_valid_url_with_port_and_path(self):
+    def test_convert_to_valid_url_with_port_and_path(self) -> None:
         """Extract path with port specified"""
-        url, path = convert_to_valid_url("https://demo.sightmachine.io:8080/nested/path")
+        url, path = convert_to_valid_url(
+            "https://demo.sightmachine.io:8080/nested/path"
+        )
         assert url == "https://demo.sightmachine.io:8080"
         assert path == "/nested/path"
 
-    def test_convert_to_valid_url_simple_tenant_with_custom_domain(self):
+    def test_convert_to_valid_url_simple_tenant_with_custom_domain(self) -> None:
         """Simple tenant with custom domain"""
         url, path = convert_to_valid_url("demo", default_domain="custom.io")
         assert url == "https://demo.custom.io"
         assert path is None
 
-    def test_convert_to_valid_url_http_protocol(self):
+    def test_convert_to_valid_url_http_protocol(self) -> None:
         """HTTP protocol instead of HTTPS"""
         url, path = convert_to_valid_url("http://demo.sightmachine.io/nested")
         assert url == "http://demo.sightmachine.io"
         assert path == "/nested"
 
-    def test_convert_to_valid_url_empty_path(self):
+    def test_convert_to_valid_url_empty_path(self) -> None:
         """URL with trailing slash but no actual path"""
         url, path = convert_to_valid_url("https://demo.sightmachine.io/")
         assert url == "https://demo.sightmachine.io"
         assert path is None
 
-    def test_convert_to_valid_url_single_level_path(self):
+    def test_convert_to_valid_url_single_level_path(self) -> None:
         """Single level path extraction"""
         url, path = convert_to_valid_url("demo.sightmachine.io/api")
         assert url == "https://demo.sightmachine.io"
         assert path == "/api"
 
-    def test_convert_to_valid_url_adds_default_domain(self):
+    def test_convert_to_valid_url_adds_default_domain(self) -> None:
         """Adds default domain when not present"""
         url, path = convert_to_valid_url("demo/nested/path")
         assert url == "https://demo.sightmachine.io"


### PR DESCRIPTION
Add new support for path-based multi-tenancy, with options in client initialization.

* new `base_path` parameter to explicitly set the base path for the environment
* ability to extract the base path if a full base url is given at initialization
  * `base_path` parameter will take precedence
* should be backwards compatible if no path is given

Manual testing can be done against `https://sm-nested-path.test.sightmachine.io/nested/one/two/`:

```python
from smsdk import client

cli = client.Client('sm-nested-path.test', base_path='/nested/one/two/')

# OR:
# cli = client.Client('sm-nested-path.test.sightmachine.io/nested/one/two/')

cli.login('apikey', key_id='<your_api_key>', secret_id='<your_api_secret'>')

cli.get_machine_type_names()
# ['Packer', 'Palletizer', 'L1 Warmer', 'Electricity', 'Line 1', 'Filtec', 'Wrapper', 'L1-Depal', 'Empty Can Conveyor', 'L1 Case Conveyor', 'Filler', 'L1 Full Can Conveyor', 'Blender_1']
```

Also fixed some tests that were already failing in `master`. Most of these are due to the fact that it queries for data in the `demo` environment, and the data available has changed at some point. The final failing test, `test_get_line_data`, is an actual bug in MA, fixed with https://github.com/sightmachine/ma/pull/8631 .